### PR TITLE
Modify the call to abc and fix Package.swift file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 /.build
 /Packages
+*.resolve
+*.resolved
 /*.xcodeproj

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ debug: tools
 release: tools
 	swift build --configuration release -Xcc -O3 -Xcc -DNDEBUG -Xswiftc -Ounchecked
 
+releaseNoTools:
+	swift build --configuration release -Xcc -O3 -Xcc -DNDEBUG -Xswiftc -Ounchecked
+
 test:
 	swift test
 

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ debug: tools
 release: tools
 	swift build --configuration release -Xcc -O3 -Xcc -DNDEBUG -Xswiftc -Ounchecked
 
-releaseNoTools:
-	swift build --configuration release -Xcc -O3 -Xcc -DNDEBUG -Xswiftc -Ounchecked
-
 test:
 	swift test
 
@@ -28,12 +25,12 @@ Tools/.f:
 	touch Tools/.f
 
 # abc
-Tools/abc: Tools/abc-build
-	cd Tools ; mv abc build-abc ; cp build-abc/abc .
+Tools/abc: Tools/abc-git/abc
+	cd Tools ;  cp abc-git/abc .
 
-Tools/abc-build: Tools/abc-git
-	make -C Tools/abc
+Tools/abc-git/abc: Tools/abc-git
+	make -C Tools/abc-git
 
 Tools/abc-git: Tools/.f
-	cd Tools ; git clone https://github.com/berkeley-abc/abc 
+	cd Tools ; git clone https://github.com/berkeley-abc/abc abc-git
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,6 @@ let package = Package(
         ],
     targets: [
         .target(name: "SafetySynth", dependencies: ["SafetyGameSolver"]),
-        .target(name: "SafetyGameSolver", dependencies: ["CAiger", "CUDD", "Aiger"]),
+        .target(name: "SafetyGameSolver", dependencies: ["CAiger", "CAigerHelper", "CUDD", "Aiger"]),
         ]
 )

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ It follows the rules of the [Reactive Synthesis Competition](http://www.syntcomp
 
 * Requires Swift (version 3.1)
 * `make release` builds dependencies and the binary
-* `cp Tools/abc /usr/local/bin`
 * `.build/release/SafetySynth [--synthesize] instance.aag`
+
 
 ## How to Generate AIGER Synthesis Files
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ It follows the rules of the [Reactive Synthesis Competition](http://www.syntcomp
 
 * Requires Swift (version 3.1)
 * `make release` builds dependencies and the binary
+* `cp Tools/abc /usr/local/bin`
 * `.build/release/SafetySynth [--synthesize] instance.aag`
-
 
 ## How to Generate AIGER Synthesis Files
 

--- a/Sources/SafetyGameSolver/AigerHelper.swift
+++ b/Sources/SafetyGameSolver/AigerHelper.swift
@@ -84,10 +84,11 @@ public func minimizeWithABC(_ aig: UnsafeMutablePointer<aiger>) -> UnsafeMutable
         abcCommand += " dfraig; rewrite -zl; dfraig;"
     }
     abcCommand += " write \(outputPath);"
-    
+  
+    // Execute command "abc -q abcCommand" in bash 
     let task = Process()
-    task.launchPath = "./Tools/abc"
-    task.arguments = ["-q", abcCommand]
+    task.launchPath = "/bin/bash"
+    task.arguments = ["-c", "abc -q \"" + abcCommand + "\""]
     task.standardOutput = FileHandle.standardError
     task.launch()
     task.waitUntilExit()

--- a/Sources/SafetyGameSolver/AigerHelper.swift
+++ b/Sources/SafetyGameSolver/AigerHelper.swift
@@ -85,10 +85,16 @@ public func minimizeWithABC(_ aig: UnsafeMutablePointer<aiger>) -> UnsafeMutable
     }
     abcCommand += " write \(outputPath);"
   
-    // Execute command "abc -q abcCommand" in bash 
+    // Execute command "abc -q abcCommand"
     let task = Process()
-    task.launchPath = "/bin/bash"
-    task.arguments = ["-c", "abc -q \"" + abcCommand + "\""]
+    // determine `abc` binary, either local or system
+    var env = ProcessInfo.processInfo.environment
+    var path = env["PATH"]! as String
+    path = "./Tools/:" + path
+    env["PATH"] = path
+    task.environment = env
+    task.launchPath = "/usr/bin/env"
+    task.arguments = ["abc", "-q", abcCommand]
     task.standardOutput = FileHandle.standardError
     task.launch()
     task.waitUntilExit()


### PR DESCRIPTION
This commit modifies the call to abc in file AigerHelper.swift, by
executing "abc -q abcCommand" in bash. It assumes to have abc installed:
this has been specified in README.md, where the condition
  `cp Tools/abc /usr/local/bin`
has been added. Now the synthesis of the circuit should work from any
directory.

It fixes file "Package.swift" by adding "CAigerHelper" to the
set of dependencies of "SafetyGameSolver" (it does not compile otherwise).